### PR TITLE
start on weather changes

### DIFF
--- a/almanacmodules/day_roller.py
+++ b/almanacmodules/day_roller.py
@@ -89,7 +89,7 @@ class DayRoller:
         self.master_timer.update()
 
     def _create_sqlite_tables(self):
-        regional_weather = """CREATE TABLE IF NOT EXISTS regional_weather (day_num INTEGER NOT NULL, year INTEGER NOT NULL, season STRING NOT NULL, region_id INTEGER NOT NULL, biome_name STRING NOT NULL, precipitation BOOL NOT NULL, severity INTEGER NOT NULL, duration INTEGER NOT NULL, weight INTEGER NOT NULL, precip_event BOOL NOT NULL)"""
+        regional_weather = """CREATE TABLE IF NOT EXISTS regional_weather (day_num INTEGER NOT NULL, year INTEGER NOT NULL, season STRING NOT NULL, region_id INTEGER NOT NULL, biome_name STRING NOT NULL, precipitation BOOL NOT NULL, severity INTEGER NOT NULL, duration INTEGER NOT NULL, precip_value INTEGER NOT NULL, precip_event BOOL NOT NULL)"""
         natural_events = """CREATE TABLE IF NOT EXISTS natural_events (day_num INTEGER NOT NULL, year INTEGER NOT NULL, season STRING NOT NULL, region_id INTEGER NOT NULL, biome_name STRING NOT NULL, event_name STRING NOT NULL, severity INTEGER NOT NULL, event_description STRING NOT NULL)"""
         astral_events = """CREATE TABLE IF NOT EXISTS astral_events (day_num INTEGER NOT NULL, year INTEGER NOT NULL, season STRING NOT NULL, astral_name STRING NOT NULL, astral_type STRING NOT NULL, event_description STRING NOT NULL)"""
         master_timeline = """CREATE TABLE IF NOT EXISTS master_timeline (day_num INTEGER NOT NULL, year INTEGER NOT NULL, season STRING NOT NULL, region_id INTEGER NOT NULL, biome_name STRING NOT NULL, precip_event BOOL NOT NULL, astral_event STRING NOT NULL, natural_event STRING NOT NULL)"""

--- a/almanacmodules/get_args.py
+++ b/almanacmodules/get_args.py
@@ -104,6 +104,7 @@ class GetArguments:
                 "location_name": self.args.input_location,
                 "location_id": None,
                 "temp_zone": None,
+                "biomes": self.yaml_config["biomes"],
             },
             "year_info": {
                 "start_year": self.yaml_config["start_year"],
@@ -137,6 +138,7 @@ class GetArguments:
             "season_name": self.yaml_config["seasons"][
                 (self.yaml_config["season_num_start"])
             ],
+            "seasons": self.yaml_config["seasons"],
         }
         return time
 

--- a/almanacmodules/get_sheets.py
+++ b/almanacmodules/get_sheets.py
@@ -17,7 +17,7 @@ from googleapiclient.discovery import build
 
 # PERSONAL
 from almanacmodules import cred_check
-from almanacmodules import config
+from almanacmodules import pydantic_models
 
 EXTENDED_CFG_ID = "16Q2BKEWQW5A2nQ77AQbSINZ7tG4LJRVhGHfvfKHC0EM"
 ranges = (
@@ -102,7 +102,7 @@ class SheetConversion:
         world_model = []
         for row in world_raw:
             world_model.append(
-                config.world(
+                pydantic_models.world(
                     id=row[0],
                     name=row[1],
                     type=row[2],
@@ -127,7 +127,7 @@ class SheetConversion:
         monster_model = []
         for row in monster_raw:
             monster_model.append(
-                config.monster(
+                pydantic_models.monster(
                     id=row[0],
                     name=row[1],
                     type=row[2],
@@ -148,18 +148,20 @@ class SheetConversion:
 
         biome_model = []
         for row in biome_raw:
-            biome_model.append(config.biome(id=row[0], name=row[1]))
+            biome_model.append(pydantic_models.biome(id=row[0], name=row[1]))
 
         astral_model = []
         for row in astral_raw:
             astral_model.append(
-                config.astral(id=row[0], name=row[1], type=row[2], moon_of=row[3])
+                pydantic_models.astral(
+                    id=row[0], name=row[1], type=row[2], moon_of=row[3]
+                )
             )
 
         natural_model = []
         for row in natural_raw:
             natural_model.append(
-                config.natural(
+                pydantic_models.natural(
                     id=row[0],
                     name=row[1],
                     forest=row[2],
@@ -182,7 +184,7 @@ class SheetConversion:
         effects_model = []
         for row in effects_raw:
             effects_model.append(
-                config.effects(
+                pydantic_models.effects(
                     id=row[0],
                     type=row[1],
                     rarity=row[2],

--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,6 @@ event_names: ["astral", "natural"]
 
 # weather constants
 base_precip_chance: 0
+
+# location
+biomes: ["forest", "plains", "desert", "swamp", "jungle", "mountain", "lake", "river", "beach"]


### PR DESCRIPTION
- remove weight from SQLITE regional_weather
- - weight is now only used in weather.py to change the daily precip_value of each regional_biome
- - each biome starts at a unique precip_value which is adjusted each day based on if there is precipitation
- - SQLITE regional_weather weight is replaced by the precip_value
- - - event_coordinator.py now only needs to know what that single value is
- - - drawback to this system is that if a series of drought is followed by flood causing rains, it still may not flood due to the precip_value being too low

- add more reporting for daily weather changes of each biome based on season